### PR TITLE
Updated hapi to version 10.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "good-reporter": "3.1.0",
     "graphql": "0.2.6",
     "handlebars": "2.0.0",
-    "hapi": "8.8.1",
+    "hapi": "10.1.0",
     "hapi-auth-cookie": "2.2.0",
     "hapi-cache-buster": "0.4.0",
     "hapi-relax": "1.0.1",


### PR DESCRIPTION
:rocket:

One of your dependencies has just updated, so this PR bumps the corresponding version number in your `package.json`.

You can now check that the dependency update doesn't break your code, and then release the new version of your software safe in the knowledge that it will stay in this working state, regardless of _when_ your users do `$ npm install`.

Have a good day!

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>