### PR TITLE
Updated graphql to version 0.4.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "good": "6.4.0",
     "good-console": "5.1.0",
     "good-reporter": "3.1.0",
-    "graphql": "0.2.6",
+    "graphql": "0.4.7",
     "handlebars": "2.0.0",
     "hapi": "10.1.0",
     "hapi-auth-cookie": "2.2.0",


### PR DESCRIPTION
:rocket:

graphql just published version 0.4.7, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
[GitHub Release](https://github.com/graphql/graphql-js/releases/tag/v0.4.7)

Fixes:

* Validators are aware of inline fragments without type conditions (a0bf6f9bb1155a502649c8de743b4e35841b08b0)

---
The new version differs by 128 commits (ahead by 128, behind by 0).

- [a941554](https://github.com/graphql/graphql-js/commit/a941554fc56d607fecebe2188a7ca8848835c2a8): 0.4.7
- [a0bf6f9](https://github.com/graphql/graphql-js/commit/a0bf6f9bb1155a502649c8de743b4e35841b08b0): Fix validators to be aware of type-condition-less inline frags
- [b6a326b](https://github.com/graphql/graphql-js/commit/b6a326bfd3bef649b8cd82edea29c9677bef3838): 0.4.6
- [58e2b2e](https://github.com/graphql/graphql-js/commit/58e2b2ebb9af9e5f0f3ac68fb47aaaca661a96be): Merge pull request #191 from graphql/inline-fragment-op-type
- [3f1f9f5](https://github.com/graphql/graphql-js/commit/3f1f9f5759704ca9ed153c98558236a66af75153): [RFC] Type condition optional on inline fragments.
- [529257b](https://github.com/graphql/graphql-js/commit/529257b8d3319100ba66ad432a6dc8b167d9874e): Merge pull request #190 from graphql/optional-op-name
- [56f0b39](https://github.com/graphql/graphql-js/commit/56f0b39911101400e462def6880f90d1117f242c): [RFC] Make operation name optional.
- [2cfbfce](https://github.com/graphql/graphql-js/commit/2cfbfcec58f9a58d327de59ed3d378db5666bdee): properly export getOperationAST utility
- [59ea824](https://github.com/graphql/graphql-js/commit/59ea82470804393d3d8697a4b78f380beb5c6dd7): 0.4.5
- [75ce8b1](https://github.com/graphql/graphql-js/commit/75ce8b1f1e90484ced2291a9cbd8bce978990553): Early errors for misuse of deprecation
- [6f2b66d](https://github.com/graphql/graphql-js/commit/6f2b66df332625a8f2269836f774e91d750e00ac): Clearer lex errors for unprintable unicode
- [4bd4b33](https://github.com/graphql/graphql-js/commit/4bd4b33a5a48cff0c4382e6873555bed9adadb00): terminology nit
- [f66ddf5](https://github.com/graphql/graphql-js/commit/f66ddf55f93010f7e2ca4ca717d522d4d0d4b12b): getOperationAST utility function
- [1bf2537](https://github.com/graphql/graphql-js/commit/1bf253734e32be518dd2bf693de0612969e1e847): fix lint
- [da5c4b0](https://github.com/graphql/graphql-js/commit/da5c4b0814887382067dcaeaddd6fed8a76a3614): Add parser test containing tricky multi-byte


There are 128 commits in total. See the [full diff](https://github.com/graphql/graphql-js/compare/f5f6946ea74aaf9c9b2c098b63110f88714a716f...a941554fc56d607fecebe2188a7ca8848835c2a8).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>