### PR TITLE
Updated hapi to version 10.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "good-reporter": "3.1.0",
     "graphql": "0.2.6",
     "handlebars": "2.0.0",
-    "hapi": "10.1.0",
+    "hapi": "10.2.0",
     "hapi-auth-cookie": "2.2.0",
     "hapi-cache-buster": "0.4.0",
     "hapi-relax": "1.0.1",


### PR DESCRIPTION
:rocket:

hapi just published version 10.2.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 38 commits (ahead by 38, behind by 0).

- [a063aba](https://github.com/hapijs/hapi/commit/a063abaa1ac5576a01c3a0b5de07a782a9d2712a): Fix single connection bug. Closes #2813
- [2f23298](https://github.com/hapijs/hapi/commit/2f232985f163d64bb58bd37276692346b6bd502b): Clarify payload validation rules. Closes #2722
- [15d2cc7](https://github.com/hapijs/hapi/commit/15d2cc73de12b9e4fdf191564179997862a2a968): after() cleanup. Closes #2815
- [79baeb0](https://github.com/hapijs/hapi/commit/79baeb0f10bae39899621741b1f32d7ab5028662): Load plugin once. Closes #2761. Closes #2797
- [b947135](https://github.com/hapijs/hapi/commit/b9471359dc34265a81c0a6b32316ce53f21165e6): Assert when adding after() after init. Closes #2812
- [e0d66e8](https://github.com/hapijs/hapi/commit/e0d66e80de3f817675c682ff6efad80e4d252d3b): expose plugin registration. Closes #2777
- [c34a556](https://github.com/hapijs/hapi/commit/c34a556216d7433c961028bd650cc6606a183ba8): CORS merge mode. Closes #2733
- [fb78edf](https://github.com/hapijs/hapi/commit/fb78edf21cc1304c7161a9ba58895b1c93b30122): Plugin attributes.connections. Closes #2809. Closes #2811
- [e8ebf5b](https://github.com/hapijs/hapi/commit/e8ebf5bc200d1b9a9b1e115e14d15626787b99fa): git push origin masterMerge branch 'jefflembeck-http-response-splitting'
- [2afb874](https://github.com/hapijs/hapi/commit/2afb8743833398791006e097a75970ac983f9e77): merge and cleanup
- [9c79f5c](https://github.com/hapijs/hapi/commit/9c79f5c4b2d826303f6e7158cbc94deb73e0ede6): Merge pull request #2795 from vertiman/master
- [0ac67fc](https://github.com/hapijs/hapi/commit/0ac67fc14c36654db5cd6df02d9b28156e58e584): Move start/initialize errors to callback. Closes #2808
- [6120f43](https://github.com/hapijs/hapi/commit/6120f4395e09c009f27f84ba4ba752d034252406): Move stop() error to callback. Closes #2736
- [23760c7](https://github.com/hapijs/hapi/commit/23760c7f0df3ad114e23c4e3fe24cea96d47103b): Cleanup for #2796
- [6c5ab9f](https://github.com/hapijs/hapi/commit/6c5ab9fdd23562940eaa36608577435942262da1): Merge pull request #2796 from ldesplat/fix-vary-duplicate


There are 38 commits in total. See the [full diff](https://github.com/hapijs/hapi/compare/c2f67521561d63610b2ab3e031d895dd049c1dbb...a063abaa1ac5576a01c3a0b5de07a782a9d2712a).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>